### PR TITLE
Optimized the code

### DIFF
--- a/code.ino
+++ b/code.ino
@@ -8,7 +8,7 @@ AF_DCMotor motor2(2, MOTOR12_1KHZ);
 AF_DCMotor motor3(3, MOTOR34_1KHZ);
 AF_DCMotor motor4(4, MOTOR34_1KHZ);
 
-char command; 
+//char command; 
 
 void setup() 
 {       
@@ -16,24 +16,24 @@ void setup()
 }
 
 void loop(){
-  if(Serial.available() > 0){ 
-    command = Serial.read(); 
-    Stop(); //initialize with motors stoped
+  if(Serial.available()){             //If Serial.available() returns any value greater than 0, control enters the while loop.
+    //command = Serial.read(); 
+    Stop(); //initialize with motors stopped
     //Change pin mode only if new command is different from previous.   
     //Serial.println(command);
-    switch(command){
-    case 'F':  
-      forward();
-      break;
-    case 'B':  
-       back();
-      break;
-    case 'L':  
-      left();
-      break;
-    case 'R':
-      right();
-      break;
+    switch(Serial.read()){
+      case 'F':  
+        forward();
+        break;
+      case 'B':  
+         back();
+        break;
+      case 'L':  
+        left();
+        break;
+      case 'R':
+        right();
+        break;
     }
   } 
 }


### PR DESCRIPTION
On line 19:
You need not compare the return value with 0. If Serial.available() returns any value greater than 0, control enters the while loop. Any value greater than 0 is treated as 1.

On lines 11, 20 & 24:
You can directly pass the return value of Serial.read() by calling the method inside the switch itself (line 20).
If this approach is used, then it is unnecessary to create and initialize the 'command' variable.

I have made the above changes and commented the unnecessary lines of code. Oh, and also I fixed the indentation for the switch block.